### PR TITLE
FastIgnore update

### DIFF
--- a/.spellr.yml
+++ b/.spellr.yml
@@ -1,8 +1,8 @@
 ---
-ignore:
+excludes:
   - wordlists/*
   - data/*
-only:
+includes:
   - '*.rb'
   - '*.yml'
   - '*.txt'
@@ -12,9 +12,9 @@ only:
   - Gemfile
 languages:
   ruby:
-    only:
+    includes:
       - README.md
   lorem:
-    only:
+    includes:
       - spec/*
       - .spellr.yml

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,14 @@
+# v0.4.0 (unreleased)
+- LOTS of performance improvements. it's about 4 times faster
+- significantly better key heuristic matching, with configurable weight (`key_heuristic_weight`).
+- Update FastIgnore dependency.
+- Change the yml format slightly. `ignore` is now `excludes`. `only` is now `includes`
+  I feel like this makes more sense for the way the config is merged. and the right time to do it is when you'll probably have to tweak it anyway because:
+- the `only`/`includes` items are now parsed using FastIgnore's gitignore inspired allow list format
+  (see https://github.com/robotdana/fast_ignore#using-an-includes-list)
+  Mostly it's the same just more flexible, though there may need to be some small adjustments.
+- the cli arguments are now also managed using FastIgnore's rules, fixing issues with absolute paths and paths beginning with `./` also it's a LOT faster when just checking a single file, basically instant. so that's nice.
+
 # v0.3.2
 - add automatic rubygems and dockerhub deploy
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,8 +1,8 @@
 PATH
   remote: .
   specs:
-    spellr (0.3.2)
-      fast_ignore
+    spellr (0.4.0)
+      fast_ignore (~> 0.4.0)
 
 GEM
   remote: https://rubygems.org/
@@ -10,7 +10,7 @@ GEM
     ast (2.4.0)
     coderay (1.1.2)
     diff-lcs (1.3)
-    fast_ignore (0.3.3)
+    fast_ignore (0.4.0)
     jaro_winkler (1.5.3)
     method_source (0.9.2)
     parallel (1.17.0)

--- a/lib/.spellr.yml
+++ b/lib/.spellr.yml
@@ -3,7 +3,7 @@ word_minimum_length: 3
 key_heuristic_weight: 5
 key_minimum_length: 6
 
-ignore: # this list is parsed with the .gitignore format
+excludes: # this list is parsed with the .gitignore format
   - .git/
   - .spellr_wordlists/
   - .DS_Store
@@ -31,7 +31,7 @@ languages:
     generate: "fetch english"
     # TODO: don't generate the ruby file until you actually need one
   ruby:
-    only: # Filtered using File.fn_match
+    includes: # Filtered using gitignore format
       - '*.rb'
       - '*.rake'
       - '*.gemspec'
@@ -45,7 +45,7 @@ languages:
     hashbangs:
       - ruby
   html:
-    only:
+    includes:
       - '*.html'
       - '*.hml'
       - '*.jsx'
@@ -62,7 +62,7 @@ languages:
       - '*.sass'
       - '*.less'
   js:
-    only:
+    includes:
       - '*.html'
       - '*.hml'
       - '*.jsx'
@@ -74,22 +74,22 @@ languages:
       - '*.erb'
       - '*.json'
   shell:
-    only:
+    includes:
       - '*.sh'
       - Dockerfile
     hashbangs:
       - bash
       - sh
   dockerfile:
-    only:
+    includes:
       - Dockerfile
   css:
-    only:
+    includes:
       - '*.css'
       - '*.sass'
       - '*.scss'
   xml:
-    only:
+    includes:
       - '*.xml'
       - '*.html'
       - '*.haml'

--- a/lib/spellr.rb
+++ b/lib/spellr.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require_relative 'spellr/backports'
 require_relative 'spellr/config'
 
 module Spellr

--- a/lib/spellr/backports.rb
+++ b/lib/spellr/backports.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+class Array
+  unless RUBY_VERSION >= '2.4'
+    def sum
+      reduce(0) do |total, value|
+        total + if block_given?
+          yield value
+        else
+          value
+        end
+      end
+    end
+  end
+end
+
+class String
+  alias_method :match?, :match unless RUBY_VERSION >= '2.4'
+end

--- a/lib/spellr/config.rb
+++ b/lib/spellr/config.rb
@@ -7,7 +7,7 @@ require_relative 'reporter'
 require 'pathname'
 
 module Spellr
-  class Config
+  class Config # rubocop:disable Metrics/ClassLength
     attr_writer :reporter
     attr_reader :config_file
     attr_accessor :quiet
@@ -47,25 +47,46 @@ module Spellr
       @key_minimum_length ||= @config[:key_minimum_length]
     end
 
-    def only
-      @config[:only] || []
+    def includes
+      return @includes if defined?(@includes)
+
+      if @config[:only]
+        warn <<~WARNING
+          \e[33mSpellr: `only:` yaml key with a list of fnmatch rules is deprecated.
+          Please use `includes:` instead, which uses gitignore-inspired rules.
+          see github.com/robotdana/fast_ignore#using-an-includes-list for details\e[0m
+        WARNING
+      end
+
+      @includes = (@config[:includes] || []) + (@config[:only] || [])
     end
 
-    def ignored
-      @config[:ignore]
+    def excludes
+      return @excludes if defined?(@excludes)
+
+      if @config[:ignore]
+        warn <<~WARNING
+          \e[33mSpellr: `ignore:` yaml key is deprecated.
+          Please use `excludes:` instead.\e[0m
+        WARNING
+      end
+
+      @excludes = (@config[:excludes] || []) + (@config[:ignore] || [])
     end
 
     def color
       @config[:color]
     end
 
-    def clear_cache # rubocop:disable Metrics/CyclomaticComplexity
+    def clear_cache # rubocop:disable Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
       remove_instance_variable(:@wordlists) if defined?(@wordlists)
       remove_instance_variable(:@languages) if defined?(@languages)
       remove_instance_variable(:@errors) if defined?(@errors)
       remove_instance_variable(:@word_minimum_length) if defined?(@word_minimum_length)
       remove_instance_variable(:@key_heuristic_weight) if defined?(@key_heuristic_weight)
       remove_instance_variable(:@key_minimum_length) if defined?(@key_minimum_length)
+      remove_instance_variable(:@excludes) if defined?(@excludes)
+      remove_instance_variable(:@includes) if defined?(@includes)
     end
 
     def languages

--- a/lib/spellr/file.rb
+++ b/lib/spellr/file.rb
@@ -2,6 +2,8 @@
 
 require 'pathname'
 
+# TODO: maybe just extend pathname if you have to
+
 module Spellr
   class File < Pathname
     def self.wrap(file)
@@ -9,27 +11,16 @@ module Spellr
     end
 
     def hashbang
-      return if extname != ''
-      return unless first_line&.start_with?('#!')
+      @hashbang ||= begin
+        return if extname != ''
+        return unless first_line&.start_with?('#!')
 
-      first_line
+        first_line
+      end
     end
 
     def first_line
       @first_line ||= each_line.first
-    end
-
-    def basename
-      @basename ||= super.to_s
-    end
-
-    def fnmatch?(pattern)
-      relative_path.fnmatch?(pattern, ::File::FNM_DOTMATCH) ||
-        ::File.fnmatch?(basename, pattern, ::File::FNM_DOTMATCH)
-    end
-
-    def relative_path
-      @relative_path ||= relative_path_from(Spellr.config.pwd)
     end
   end
 end

--- a/lib/spellr/key_tuner/stats.rb
+++ b/lib/spellr/key_tuner/stats.rb
@@ -1,19 +1,5 @@
 # frozen_string_literal: true
 
-class Array
-  unless RUBY_VERSION >= '2.4'
-    def sum
-      reduce(0) do |total, value|
-        total + if block_given?
-          yield value
-        else
-          value
-        end
-      end
-    end
-  end
-end
-
 module Stats
   def mean(values, &block)
     return 0 if values.empty?

--- a/lib/spellr/line_tokenizer.rb
+++ b/lib/spellr/line_tokenizer.rb
@@ -169,13 +169,17 @@ module Spellr
       end
     end
 
-    MIN_ALPHA_RE = /(?:
-      [A-Z][a-z]{#{Spellr.config.word_minimum_length - 1}}
-      |
-      [a-z]{#{Spellr.config.word_minimum_length}}
-      |
-      [A-Z]{#{Spellr.config.word_minimum_length}}
-    )/x.freeze
+    # this is in a method becase the minimum word length stuff was throwing it off
+    # TODO: move to config maybe?
+    def min_alpha_re
+      /(?:
+        [A-Z][a-z]{#{Spellr.config.word_minimum_length - 1}}
+        |
+        [a-z]{#{Spellr.config.word_minimum_length}}
+        |
+        [A-Z]{#{Spellr.config.word_minimum_length}}
+      )/x.freeze
+    end
     ALPHA_SEP_RE = '[A-Za-z][A-Za-z\\-_/+]*'
     NUM_SEP_RE = '\\d[\\d\\-_/+]*'
     THREE_CHUNK_RE = /^(?:
@@ -186,7 +190,7 @@ module Spellr
     def key_roughly?(matched)
       return unless matched.length >= Spellr.config.key_minimum_length
       return unless matched.match?(THREE_CHUNK_RE)
-      return unless matched.match?(MIN_ALPHA_RE) # or there's no point
+      return unless matched.match?(min_alpha_re) # or there's no point
 
       true
     end

--- a/lib/spellr/token.rb
+++ b/lib/spellr/token.rb
@@ -15,8 +15,6 @@ class String
       cache[term] = term.strip.downcase.unicode_normalize.tr('’', "'") + "\n"
     end
   end
-
-  alias_method :match?, :match unless RUBY_VERSION >= '2.4'
 end
 
 module Spellr

--- a/lib/spellr/version.rb
+++ b/lib/spellr/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Spellr
-  VERSION = '0.3.2'
+  VERSION = '0.4.0'
 end

--- a/spec/cli_spec.rb
+++ b/spec/cli_spec.rb
@@ -104,7 +104,7 @@ RSpec.describe 'command line', type: :cli do
     end
 
     it 'returns the list of files when given a dir to subset' do
-      run('spellr --dry-run lib/\*')
+      run('spellr --dry-run lib/')
 
       expect(stderr).to be_empty
       expect(exitstatus).to eq 0
@@ -131,7 +131,7 @@ RSpec.describe 'command line', type: :cli do
 
       stub_fs_file '.spellr.yml', <<~FILE
         color: true
-        ignore:
+        excludes:
           - .spellr.yml
         languages:
           english:

--- a/spec/file_list_spec.rb
+++ b/spec/file_list_spec.rb
@@ -46,7 +46,7 @@ RSpec.describe Spellr::FileList do
     )
   end
 
-  xit 'can respect absolute paths' do
+  it 'can respect absolute paths' do
     expect(described_class.new(Pathname.pwd.join('foo.rb').to_s).to_a).to match_relative_paths(
       'foo.rb'
     )
@@ -62,14 +62,14 @@ RSpec.describe Spellr::FileList do
 
     it 'ignores gitignore files' do
       expect(described_class.new.to_a).to match_relative_paths(
-        # '.gitignore',
+        '.gitignore',
         'spec/foo_spec.rb'
       )
     end
   end
 
   context 'with excluded files' do
-    before { stub_config(ignored: ['foo.rb', '*.txt']) }
+    before { stub_config(excludes: ['foo.rb', '*.txt']) }
 
     it 'ignores excluded files' do
       expect(described_class.new.to_a).to match_relative_paths(

--- a/spellr.gemspec
+++ b/spellr.gemspec
@@ -35,5 +35,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rubocop-rspec'
   spec.add_development_dependency 'terminal-table'
   spec.add_development_dependency 'tty_string'
-  spec.add_dependency 'fast_ignore'
+  spec.add_dependency 'fast_ignore', '~> 0.4.0'
 end


### PR DESCRIPTION
- Update FastIgnore dependency.
- Change the yml format slightly.
  `ignore` is now `excludes`. `only` is now `includes`
  I feel like this makes more sense for the way the config is merged.
  and the right time to do it is when you'll probably have to tweak it
  anyway because:
- the `only`/`includes` items are now parsed using FastIgnore's
  gitignore inspired allow list format
  (see https://github.com/robotdana/fast_ignore#using-an-includes-list)
  Mostly it's the same just more flexible, though there may need to be
  some small adjustments.
- the cli arguments are now also managed using FastIgnore's rules,
  fixing issues with absolute paths and paths beginning with `./` also
- it's a LOT faster when just checking a single file, basically instant.
  so that's nice.

  fixes #38
  fixes #37