### PR TITLE
Massive test refactor

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -117,7 +117,7 @@ Metrics/BlockLength:
     - describe
     - context
     - it
-    - run_exe
+    - spellr
 
 Layout/LineLength:
   Max: 100

--- a/.simplecov
+++ b/.simplecov
@@ -24,6 +24,9 @@ module Parallel
     pid = Process.fork do
       # here begins my additions
       SimpleCov.command_name "Parallel #{Process.pid}"
+      SimpleCov.formatter SimpleCov::Formatter::SimpleFormatter
+      SimpleCov.minimum_coverage 0
+      SimpleCov.print_error_status = false
       SimpleCov.start
       # here ends my additions
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# v0.8.2
+- Massive test refactor
+  - Spellr now only pays attention to Spellr.pwd. Dir.pwd can be whatever
+  - All output goes through Spellr.config.output. Now we can override it.
+  - tests are twice as fast. Fewer warnings
+- upgrade fast_ignore dependency
+
 # v0.8.1
 - use refinements for backports so that RakeTask doesn't conflict with Rubocop::RakeTask
 

--- a/exe/spellr
+++ b/exe/spellr
@@ -3,4 +3,4 @@
 
 require_relative '../lib/spellr/cli'
 
-Spellr::CLI.new(ARGV)
+exit Spellr::CLI.new(ARGV).run

--- a/lib/spellr.rb
+++ b/lib/spellr.rb
@@ -2,6 +2,7 @@
 
 require_relative 'spellr/backports'
 require_relative 'spellr/config'
+require_relative 'spellr/pwd'
 
 module Spellr
   class Error < StandardError; end
@@ -26,5 +27,9 @@ module Spellr
 
   def config
     @config ||= Spellr::Config.new
+  end
+
+  def exit(status = 0)
+    throw(:spellr_exit, status)
   end
 end

--- a/lib/spellr/base_reporter.rb
+++ b/lib/spellr/base_reporter.rb
@@ -40,7 +40,7 @@ module Spellr
     end
 
     def output
-      @output ||= Spellr::Output.new
+      @output ||= Spellr.config.output
     end
 
     def counts

--- a/lib/spellr/check_dry_run.rb
+++ b/lib/spellr/check_dry_run.rb
@@ -7,7 +7,7 @@ module Spellr
   class CheckDryRun < Check
     def check
       files.each do |file|
-        puts file.relative_path
+        @reporter.puts file.relative_path
       end
     end
   end

--- a/lib/spellr/cli_options.rb
+++ b/lib/spellr/cli_options.rb
@@ -9,6 +9,8 @@ module Spellr
     class Options
       class << self
         def parse(argv)
+          @parallel_option = false
+
           options.parse!(argv)
         end
 
@@ -55,7 +57,7 @@ module Spellr
         end
 
         def config_option(file)
-          file = Pathname.pwd.join(file).expand_path
+          file = Spellr.pwd.join(file).expand_path
 
           unless ::File.readable?(file)
             raise Spellr::Config::NotFound, "Config error: #{file} not found or not readable"
@@ -81,15 +83,15 @@ module Spellr
 
         def version_option(_)
           require_relative 'version'
-          puts(Spellr::VERSION)
+          Spellr.config.output.puts(Spellr::VERSION)
 
-          exit
+          Spellr.exit
         end
 
         def options_help(_)
-          puts options.help
+          Spellr.config.output.puts options.help
 
-          exit
+          Spellr.exit
         end
       end
     end

--- a/lib/spellr/config.rb
+++ b/lib/spellr/config.rb
@@ -4,6 +4,8 @@ require_relative '../spellr'
 require_relative 'config_loader'
 require_relative 'language'
 require_relative 'config_validator'
+require_relative 'output'
+
 require 'pathname'
 
 module Spellr
@@ -44,14 +46,6 @@ module Spellr
       end
     end
 
-    def pwd
-      @pwd ||= Pathname.new(ENV['SPELLR_TEST_PWD'] || Dir.pwd)
-    end
-
-    def pwd_s
-      @pwd_s ||= pwd.to_s
-    end
-
     def languages_for(file)
       languages.select { |l| l.matches?(file) }
     end
@@ -63,6 +57,10 @@ module Spellr
     def config_file=(value)
       reset!
       @config = ConfigLoader.new(value)
+    end
+
+    def output
+      @output ||= Spellr::Output.new
     end
 
     def reporter
@@ -104,11 +102,6 @@ module Spellr
     def default_checker
       require_relative 'check_parallel'
       Spellr::CheckParallel
-    end
-
-    def clear_pwd # leftovers:test
-      remove_instance_variable(:@pwd) if defined?(@pwd)
-      remove_instance_variable(:@pwd_s) if defined?(@pwd_s)
     end
   end
 end

--- a/lib/spellr/config_loader.rb
+++ b/lib/spellr/config_loader.rb
@@ -11,7 +11,7 @@ module Spellr
 
     attr_reader :config_file
 
-    def initialize(config_file = ::File.join(Dir.pwd, '.spellr.yml'))
+    def initialize(config_file = ::File.join(Spellr.pwd, '.spellr.yml'))
       @config_file = config_file
     end
 

--- a/lib/spellr/config_validator.rb
+++ b/lib/spellr/config_validator.rb
@@ -23,9 +23,9 @@ module Spellr
 
       # I have no idea how to check for this other than call it
       Timeout.timeout(0.0000000000001) do
-        $stdin.getch
+        Spellr.config.output.stdin.getch
       end
-    rescue Errno::ENOTTY, Errno::ENODEV
+    rescue Errno::ENOTTY, Errno::ENODEV, IOError
       errors << 'CLI error: --interactive is unavailable in a non-interactive terminal'
     rescue Timeout::Error
       nil

--- a/lib/spellr/file.rb
+++ b/lib/spellr/file.rb
@@ -24,7 +24,7 @@ module Spellr
     end
 
     def relative_path
-      @relative_path ||= relative_path_from(Spellr.config.pwd)
+      @relative_path ||= relative_path_from(Spellr.pwd)
     end
 
     def insert(string, range)

--- a/lib/spellr/file_list.rb
+++ b/lib/spellr/file_list.rb
@@ -31,7 +31,7 @@ module Spellr
         ignore_rules: Spellr.config.excludes,
         include_rules: Spellr.config.includes,
         argv_rules: @patterns,
-        root: Spellr.config.pwd_s
+        root: Spellr.pwd_s
       )
     end
   end

--- a/lib/spellr/interactive.rb
+++ b/lib/spellr/interactive.rb
@@ -126,7 +126,7 @@ module Spellr
       case stdin_getch("qaAsSrR?h\u0003\u0004")
       # :nocov:
       when 'q', "\u0003" # ctrl c
-        exit 1
+        Spellr.exit 1
       when 'a', 'A'
         Spellr::InteractiveAdd.new(token, self)
       when 's', "\u0004" # ctrl d

--- a/lib/spellr/language.rb
+++ b/lib/spellr/language.rb
@@ -15,8 +15,8 @@ module Spellr
       @key = key
       @includes = includes
       @hashbangs = hashbangs
-      unless hashbangs.empty?
-        @hashbang_pattern = /\A#!.*\b(?:#{hashbangs.map { |s| Regexp.escape(s) }.join('|')})\b/
+      @hashbang_pattern = unless hashbangs.empty?
+        /\A#!.*\b(?:#{hashbangs.map { |s| Regexp.escape(s) }.join('|')})\b/
       end
       @locales = Array(locale)
       @addable = addable
@@ -36,7 +36,7 @@ module Spellr
 
     def project_wordlist
       @project_wordlist ||= Spellr::Wordlist.new(
-        Spellr.config.pwd.join('.spellr_wordlists', "#{name}.txt"),
+        Spellr.pwd.join('.spellr_wordlists', "#{name}.txt"),
         name: name
       )
     end
@@ -56,7 +56,7 @@ module Spellr
       return @hashbangs.empty? if @includes.empty?
 
       @fast_ignore ||= FastIgnore.new(
-        include_rules: @includes, gitignore: false, root: Spellr.config.pwd_s
+        include_rules: @includes, gitignore: false, root: Spellr.pwd_s
       )
       @fast_ignore.allowed?(file.to_s)
     end

--- a/lib/spellr/pwd.rb
+++ b/lib/spellr/pwd.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+require 'pathname'
+
+module Spellr
+  module_function
+
+  def pwd
+    @pwd ||= Pathname.pwd
+  end
+
+  def pwd_s
+    @pwd_s ||= pwd.to_s
+  end
+end

--- a/lib/spellr/rake_task.rb
+++ b/lib/spellr/rake_task.rb
@@ -49,9 +49,8 @@ module Spellr
     end
 
     def run(argv)
-      Spellr::CLI.new(argv)
-    rescue SystemExit => e
-      raise unless e.status == 0
+      status = Spellr::CLI.new(argv).run
+      exit 1 unless status == 0
     end
 
     def argv_or_default(task_argv)

--- a/lib/spellr/tokenizer.rb
+++ b/lib/spellr/tokenizer.rb
@@ -9,9 +9,6 @@ module Spellr
   class Tokenizer
     attr_reader :file
 
-    attr_accessor :disabled
-    alias_method :disabled?, :disabled
-
     def initialize(file, start_at: nil, skip_key: true)
       @start_at = start_at || ColumnLocation.new(line_location: LineLocation.new(file))
       @file = file.is_a?(StringIO) || file.is_a?(IO) ? file : ::File.new(file)

--- a/lib/spellr/wordlist.rb
+++ b/lib/spellr/wordlist.rb
@@ -12,7 +12,7 @@ module Spellr
 
     def initialize(file, name: file)
       path = @file = file
-      @path = Spellr.config.pwd.join('.spellr_wordlists').join(path).expand_path
+      @path = Spellr.pwd.join('.spellr_wordlists').join(path).expand_path
       @name = name
       @include = {}
     end

--- a/lib/spellr/wordlist_reporter.rb
+++ b/lib/spellr/wordlist_reporter.rb
@@ -6,7 +6,7 @@ require_relative 'base_reporter'
 module Spellr
   class WordlistReporter < Spellr::BaseReporter
     def finish
-      output.puts words.sort.join
+      puts words.sort.join unless words.empty?
     end
 
     def call(token)

--- a/spec/config_spec.rb
+++ b/spec/config_spec.rb
@@ -5,8 +5,8 @@ require_relative '../lib/spellr'
 
 RSpec.describe Spellr::Config do
   describe '#config_file=' do
-    around do |example|
-      with_temp_dir(example)
+    before do
+      with_temp_dir
     end
 
     it "reloads the config even if you've already asked it something" do
@@ -15,7 +15,7 @@ RSpec.describe Spellr::Config do
       YML
 
       expect(Spellr.config.word_minimum_length).to be 3
-      Spellr.config.config_file = "#{Dir.pwd}/my-spellr.yml"
+      Spellr.config.config_file = "#{Spellr.pwd}/my-spellr.yml"
       expect(Spellr.config.word_minimum_length).to be 2
     end
 
@@ -24,7 +24,7 @@ RSpec.describe Spellr::Config do
         word_minimum_length: 2
       YML
 
-      Spellr.config.config_file = "#{Dir.pwd}/my-spellr.yml"
+      Spellr.config.config_file = "#{Spellr.pwd}/my-spellr.yml"
       expect(Spellr.config.word_minimum_length).to be 2
     end
 
@@ -50,7 +50,7 @@ RSpec.describe Spellr::Config do
       expect(Spellr.config.includes).not_to include('*.*')
       expect(Spellr.config.excludes).not_to include('*.rb')
 
-      Spellr.config.config_file = "#{Dir.pwd}/my-spellr.yml"
+      Spellr.config.config_file = "#{Spellr.pwd}/my-spellr.yml"
 
       expect(Spellr.config.word_minimum_length).to be 2
       expect(Spellr.config.key_heuristic_weight).to be 1

--- a/spec/feature_spec.rb
+++ b/spec/feature_spec.rb
@@ -4,9 +4,9 @@ require_relative '../lib/spellr/version'
 RSpec.describe 'command line', type: :cli do
   describe '--help' do
     it 'returns the help' do
-      run_exe('spellr --help')
+      spellr('--help')
 
-      expect(stdout.chomp).to eq <<~HELP.chomp
+      expect(stdout).to have_output <<~HELP
         Usage: spellr [options] [files]
 
             -w, --wordlist                   Outputs errors in wordlist format
@@ -26,8 +26,8 @@ RSpec.describe 'command line', type: :cli do
   end
 
   describe 'bin/generate' do
-    around do |example|
-      with_temp_dir(example)
+    before do
+      with_temp_dir
     end
 
     describe 'bin/generate/ruby' do
@@ -38,14 +38,14 @@ RSpec.describe 'command line', type: :cli do
         expect(stderr).to be_empty
         # expect(stdout).to be_empty
         expect(exitstatus).to eq 0
-        expect(Pathname.pwd.join('wordlists/ruby.txt')).to exist
+        expect(Spellr.pwd.join('wordlists/ruby.txt')).to exist
 
         run_bin 'generate/ruby'
 
         expect(stderr).to be_empty
         # expect(stdout).to be_empty
         expect(exitstatus).to eq 0
-        expect(Pathname.pwd.join('wordlists/ruby.txt')).to exist
+        expect(Spellr.pwd.join('wordlists/ruby.txt')).to exist
       end
     end
 
@@ -70,7 +70,7 @@ RSpec.describe 'command line', type: :cli do
         expect(stderr).to be_empty
         expect(stdout).to be_empty
         expect(exitstatus).to eq 0
-        expect(Pathname.pwd.join('data.yml')).to exist
+        expect(Spellr.pwd.join('data.yml')).to exist
       end
     end
 
@@ -82,8 +82,8 @@ RSpec.describe 'command line', type: :cli do
         expect(stdout).to be_empty
         expect(exitstatus).to eq 0
 
-        expect(Pathname.pwd.join('wordlists/css.txt')).to exist
-        expect(Pathname.pwd.join('wordlists/css.LICENSE.md')).to exist
+        expect(Spellr.pwd.join('wordlists/css.txt')).to exist
+        expect(Spellr.pwd.join('wordlists/css.LICENSE.md')).to exist
       end
     end
 
@@ -94,8 +94,8 @@ RSpec.describe 'command line', type: :cli do
         expect(stderr).to be_empty
         expect(stdout).to be_empty
         expect(exitstatus).to eq 0
-        expect(Pathname.pwd.join('wordlists/html.txt')).to exist
-        expect(Pathname.pwd.join('wordlists/html.LICENSE.md')).to exist
+        expect(Spellr.pwd.join('wordlists/html.txt')).to exist
+        expect(Spellr.pwd.join('wordlists/html.LICENSE.md')).to exist
       end
     end
 
@@ -106,19 +106,19 @@ RSpec.describe 'command line', type: :cli do
         expect(stderr).to be_empty
         expect(stdout).to be_empty
         expect(exitstatus).to eq 0
-        expect(Pathname.pwd.join('wordlists/english.txt')).to exist
-        expect(Pathname.pwd.join('wordlists/english.LICENSE.txt')).to exist
-        expect(Pathname.pwd.join('wordlists/english/US.txt')).to exist
-        expect(Pathname.pwd.join('wordlists/english/US.LICENSE.txt')).to exist
-        expect(Pathname.pwd.join('wordlists/english/GB.txt')).to exist
-        expect(Pathname.pwd.join('wordlists/english/GB.LICENSE.txt')).to exist
+        expect(Spellr.pwd.join('wordlists/english.txt')).to exist
+        expect(Spellr.pwd.join('wordlists/english.LICENSE.txt')).to exist
+        expect(Spellr.pwd.join('wordlists/english/US.txt')).to exist
+        expect(Spellr.pwd.join('wordlists/english/US.LICENSE.txt')).to exist
+        expect(Spellr.pwd.join('wordlists/english/GB.txt')).to exist
+        expect(Spellr.pwd.join('wordlists/english/GB.LICENSE.txt')).to exist
       end
     end
   end
 
   describe 'rake' do
-    around do |example|
-      with_temp_dir(example)
+    before do
+      with_temp_dir
     end
 
     context 'with a rake task with no arguments' do
@@ -136,7 +136,7 @@ RSpec.describe 'command line', type: :cli do
 
         expect(stderr).to be_empty
         expect(exitstatus).to eq 0
-        expect(stdout).to eq <<~STDOUT.chomp
+        expect(stdout).to have_output <<~STDOUT
           rake spellr[*args]  # Run spellr
         STDOUT
       end
@@ -145,7 +145,7 @@ RSpec.describe 'command line', type: :cli do
         run_rake('spellr')
         expect(stderr).to be_empty
         expect(exitstatus).to eq 0
-        expect(stdout).to eq <<~STDOUT.chomp
+        expect(stdout).to have_output <<~STDOUT
           \e[2mspellr \e[0m
 
           1 file checked
@@ -157,7 +157,7 @@ RSpec.describe 'command line', type: :cli do
         run_rake('spellr[--quiet]')
         expect(stderr).to be_empty
         expect(exitstatus).to eq 0
-        expect(stdout).to eq <<~STDOUT.chomp
+        expect(stdout).to have_output <<~STDOUT
           \e[2mspellr --quiet\e[0m
         STDOUT
       end
@@ -166,7 +166,7 @@ RSpec.describe 'command line', type: :cli do
         run_rake
         expect(stderr).to be_empty
         expect(exitstatus).to eq 0
-        expect(stdout).to eq <<~STDOUT.chomp
+        expect(stdout).to have_output <<~STDOUT
           \e[2mspellr \e[0m
 
           1 file checked
@@ -181,7 +181,7 @@ RSpec.describe 'command line', type: :cli do
 
         expect(stderr).to be_empty
         expect(exitstatus).to eq 1
-        expect(stdout).to eq <<~STDOUT.chomp
+        expect(stdout).to have_output <<~STDOUT
           \e[2mspellr \e[0m
           #{aqua 'foo.txt:1:0'} #{red 'notaword'}
 
@@ -205,7 +205,7 @@ RSpec.describe 'command line', type: :cli do
         run_rake('-T')
         expect(stderr).to be_empty
         expect(exitstatus).to eq 0
-        expect(stdout).to eq <<~STDOUT.chomp
+        expect(stdout).to have_output <<~STDOUT
           rake spellr_quiet[*args]  # Run spellr (default args: --quiet)
         STDOUT
       end
@@ -214,7 +214,7 @@ RSpec.describe 'command line', type: :cli do
         run_rake('spellr_quiet')
         expect(stderr).to be_empty
         expect(exitstatus).to eq 0
-        expect(stdout).to eq <<~STDOUT.chomp
+        expect(stdout).to have_output <<~STDOUT
           \e[2mspellr --quiet\e[0m
         STDOUT
       end
@@ -223,7 +223,7 @@ RSpec.describe 'command line', type: :cli do
         run_rake('spellr_quiet[--no-parallel]')
         expect(stderr).to be_empty
         expect(exitstatus).to eq 0
-        expect(stdout).to eq <<~STDOUT.chomp
+        expect(stdout).to have_output <<~STDOUT
           \e[2mspellr --no-parallel\e[0m
 
           1 file checked
@@ -235,7 +235,7 @@ RSpec.describe 'command line', type: :cli do
         run_rake
         expect(stderr).to be_empty
         expect(exitstatus).to eq 0
-        expect(stdout).to eq <<~STDOUT.chomp
+        expect(stdout).to have_output <<~STDOUT
           \e[2mspellr --quiet\e[0m
         STDOUT
       end
@@ -247,7 +247,7 @@ RSpec.describe 'command line', type: :cli do
 
         expect(stderr).to be_empty
         expect(exitstatus).to eq 1
-        expect(stdout).to eq <<~STDOUT.chomp
+        expect(stdout).to have_output <<~STDOUT
           \e[2mspellr --quiet\e[0m
         STDOUT
       end
@@ -256,58 +256,72 @@ RSpec.describe 'command line', type: :cli do
 
   describe '--version' do
     it 'returns the version when given --version' do
-      run_exe('spellr --version')
+      spellr('--version')
 
       expect(stderr).to be_empty
       expect(exitstatus).to eq 0
-      expect(stdout).to eq Spellr::VERSION
+      expect(stdout).to have_output <<~STDOUT
+        #{Spellr::VERSION}
+      STDOUT
     end
 
     it 'returns the version when given -v' do
-      run_exe('spellr -v')
+      spellr('-v')
 
       expect(stderr).to be_empty
       expect(exitstatus).to eq 0
-      expect(stdout).to eq Spellr::VERSION
+      expect(stdout).to have_output <<~STDOUT
+        #{Spellr::VERSION}
+      STDOUT
     end
 
     it 'returns the version and exits when given additional options' do
-      run_exe('spellr --version --interactive')
+      spellr('--version --interactive')
 
       expect(stderr).to be_empty
       expect(exitstatus).to eq 0
-      expect(stdout).to eq Spellr::VERSION
+      expect(stdout).to have_output <<~STDOUT
+        #{Spellr::VERSION}
+      STDOUT
     end
 
     it 'returns the version and exits when given additional short options' do
-      run_exe('spellr -vi')
+      spellr('-vi')
 
       expect(stderr).to be_empty
       expect(exitstatus).to eq 0
-      expect(stdout).to eq Spellr::VERSION
+      expect(stdout).to have_output <<~STDOUT
+        #{Spellr::VERSION}
+      STDOUT
     end
 
     it 'returns the version when given both short and long options' do
-      run_exe('spellr -v --version')
+      spellr('-v --version')
 
       expect(stderr).to be_empty
       expect(exitstatus).to eq 0
-      expect(stdout).to eq Spellr::VERSION
+      expect(stdout).to have_output <<~STDOUT
+        #{Spellr::VERSION}
+      STDOUT
     end
   end
 
   describe 'combining --parallel and --interactive' do
     it 'complains when --interactive then --parallel' do
-      run_exe('spellr --interactive --parallel') do |_stdout, _stdin, _pid, stderr|
-        expect(stderr).to print <<~STDERR.chomp
+      spellr('--interactive --parallel') do
+        expect(exitstatus).to eq 1
+        expect(stdout).to be_empty
+        expect(stderr).to have_output <<~STDERR
           #{red('CLI error: --interactive is incompatible with --parallel')}
         STDERR
       end
     end
 
     it 'complains when --parallel then --interactive' do
-      run_exe('spellr --parallel --interactive') do |_stdout, _stdin, _pid, stderr|
-        expect(stderr).to print <<~STDERR.chomp
+      spellr('--parallel --interactive') do
+        expect(exitstatus).to eq 1
+        expect(stdout).to be_empty
+        expect(stderr).to have_output <<~STDERR
           #{red('CLI error: --interactive is incompatible with --parallel')}
         STDERR
       end
@@ -316,17 +330,20 @@ RSpec.describe 'command line', type: :cli do
 
   describe '--interactive in a non tty' do
     it 'complains' do
-      run_exe('spellr --interactive')
+      stdin.close
+      spellr('--interactive')
 
-      expect(stderr).to eq <<~STDERR.chomp
+      expect(exitstatus).to eq 1
+      expect(stdout).to be_empty
+      expect(stderr).to have_output <<~STDERR
         #{red('CLI error: --interactive is unavailable in a non-interactive terminal')}
       STDERR
     end
   end
 
   describe 'config validations' do
-    around do |example|
-      with_temp_dir(example)
+    before do
+      with_temp_dir
     end
 
     it 'complains with conflicting implicit keys' do
@@ -336,14 +353,16 @@ RSpec.describe 'command line', type: :cli do
           russian: {}
       YML
 
-      run_exe("spellr --config=#{Dir.pwd}/.spellr.yml")
+      spellr("--config=#{Spellr.pwd}/.spellr.yml")
 
-      expect(stderr).to eq(
-        red(
+      expect(stderr).to have_output <<~STDERR
+        #{red(
           'Config error: ruby & russian share the same language key (r). '\
           'Please define one to be different with `key:`'
-        )
-      )
+        )}
+      STDERR
+      expect(stdout).to be_empty
+      expect(exitstatus).to eq 1
     end
 
     it 'complains with conflicting explicit keys' do
@@ -354,14 +373,16 @@ RSpec.describe 'command line', type: :cli do
             key: e
       YML
 
-      run_exe("spellr --config=#{Dir.pwd}/.spellr.yml")
+      spellr("--config=#{Spellr.pwd}/.spellr.yml")
 
-      expect(stderr).to eq(
-        red(
+      expect(stderr).to have_output <<~STDERR
+        #{red(
           'Config error: english & spanish share the same language key (e). '\
           'Please define one to be different with `key:`'
-        )
-      )
+        )}
+      STDERR
+      expect(stdout).to be_empty
+      expect(exitstatus).to eq 1
     end
 
     it 'complains with multicharacter keys' do
@@ -373,27 +394,33 @@ RSpec.describe 'command line', type: :cli do
             key: ru
       YML
 
-      run_exe("spellr --config=#{Dir.pwd}/.spellr.yml")
+      spellr("--config=#{Spellr.pwd}/.spellr.yml")
 
-      expect(stderr).to eq red(<<~STDERR.chomp)
-        Config error: english defines a key that is too long (en). Please change it to be a single character
-        Config error: ruby defines a key that is too long (ru). Please change it to be a single character
+      expect(stderr).to have_output <<~STDERR
+        #{red(
+          "Config error: english defines a key that is too long (en). Please change it to be a single character\n" \
+          'Config error: ruby defines a key that is too long (ru). Please change it to be a single character'
+        )}
       STDERR
+      expect(stdout).to be_empty
+      expect(exitstatus).to eq 1
     end
 
     it 'complains with a missing specified config' do
-      run_exe("spellr --config=#{Dir.pwd}/my-spellr.yml")
+      spellr("--config=#{Spellr.pwd}/my-spellr.yml")
 
-      expect(stderr).to eq red("Config error: #{Dir.pwd}/my-spellr.yml not found or not readable")
+      expect(stderr).to have_output <<~STDERR
+        #{red("Config error: #{Spellr.pwd}/my-spellr.yml not found or not readable")}
+      STDERR
+      expect(stdout).to be_empty
+      expect(exitstatus).to eq 1
     end
   end
 
   context 'with ruby files without errors' do
-    around do |example|
-      with_temp_dir(example)
-    end
-
     before do
+      with_temp_dir
+
       stub_fs_file 'test.rb', <<~RUBY
         "string".casecmp "STRING"
       RUBY
@@ -421,11 +448,11 @@ RSpec.describe 'command line', type: :cli do
     end
 
     it 'allows the ruby files to say casecmp but not the txt file' do
-      run_exe('spellr --no-parallel') # parallel was making this test failure order random
+      spellr('--no-parallel') # parallel was making this test failure order random
 
       expect(stderr).to be_empty
       expect(exitstatus).to eq 1
-      expect(stdout).to eq <<~WORDS.chomp
+      expect(stdout).to have_output <<~WORDS
         #{aqua 'test_control.txt:1:9'} "string".#{red 'casecmp'} "STRING"
         #{aqua 'test_control_no_ext:1:9'} "string".#{red 'casecmp'} "STRING"
 
@@ -436,11 +463,9 @@ RSpec.describe 'command line', type: :cli do
   end
 
   context 'with some files' do
-    around do |example|
-      with_temp_dir(example)
-    end
-
     before do
+      with_temp_dir
+
       stub_fs_file_list %w{
         foo.md
         lib/bar.rb
@@ -448,57 +473,61 @@ RSpec.describe 'command line', type: :cli do
     end
 
     it 'returns the list of files when given no further arguments' do
-      run_exe('spellr --dry-run')
+      spellr('--dry-run')
 
       expect(stderr).to be_empty
       expect(exitstatus).to eq 0
-      expect(stdout.split("\n")).to contain_exactly(
-        'lib/bar.rb',
-        'foo.md'
+      expect(stdout.each_line.to_a).to contain_exactly(
+        "lib/bar.rb\n",
+        "foo.md\n"
       )
     end
 
     it 'can combine dry-run with no-parallel (by not being parallel in the firsts place)' do
-      run_exe('spellr --dry-run --no-parallel')
+      spellr('--dry-run --no-parallel')
 
       expect(stderr).to be_empty
       expect(exitstatus).to eq 0
-      expect(stdout.split("\n")).to contain_exactly(
-        'lib/bar.rb',
-        'foo.md'
+      expect(stdout.each_line.to_a).to contain_exactly(
+        "lib/bar.rb\n",
+        "foo.md\n"
       )
     end
 
     it 'can combine dry-run with parallel (by ignoring --parallel)' do
-      run_exe('spellr --dry-run --parallel')
+      spellr('--dry-run --parallel')
 
       expect(stderr).to be_empty
       expect(exitstatus).to eq 0
-      expect(stdout.split("\n")).to contain_exactly(
-        'lib/bar.rb',
-        'foo.md'
+      expect(stdout.each_line.to_a).to contain_exactly(
+        "lib/bar.rb\n",
+        "foo.md\n"
       )
     end
 
     it 'returns the list of files when given an extensions to subset' do
-      run_exe('spellr --dry-run \*.rb')
+      spellr('--dry-run \*.rb')
 
       expect(stderr).to be_empty
       expect(exitstatus).to eq 0
-      expect(stdout).to eq 'lib/bar.rb'
+      expect(stdout).to have_output <<~STDOUT
+        lib/bar.rb
+      STDOUT
     end
 
     it 'returns the list of files when given a dir to subset' do
-      run_exe('spellr --dry-run lib/')
+      spellr('--dry-run lib/')
 
       expect(stderr).to be_empty
       expect(exitstatus).to eq 0
-      expect(stdout).to eq 'lib/bar.rb'
+      expect(stdout).to have_output <<~STDOUT
+        lib/bar.rb
+      STDOUT
     end
 
     describe '--quiet' do
       it "doesn't output to stdout or stderr but does return the correct exitstatus" do
-        run_exe 'spellr --quiet'
+        spellr '--quiet'
 
         expect(stderr).to be_empty
         expect(exitstatus).to eq 0
@@ -508,8 +537,8 @@ RSpec.describe 'command line', type: :cli do
   end
 
   context 'with files with errors' do
-    around do |example|
-      with_temp_dir(example)
+    before do
+      with_temp_dir
     end
 
     let!(:english_wordlist) do
@@ -529,7 +558,7 @@ RSpec.describe 'command line', type: :cli do
 
     describe '--quiet' do
       it "doesn't output to stdout or stderr but does return the correct exitstatus" do
-        run_exe 'spellr --quiet'
+        spellr '--quiet'
 
         expect(stderr).to be_empty
         expect(exitstatus).to eq 1
@@ -537,7 +566,7 @@ RSpec.describe 'command line', type: :cli do
       end
 
       it "doesn't output anything but exitstatus when combined with no-parallel" do
-        run_exe 'spellr --quiet --no-parallel'
+        spellr '--quiet --no-parallel'
 
         expect(stderr).to be_empty
         expect(exitstatus).to eq 1
@@ -545,7 +574,7 @@ RSpec.describe 'command line', type: :cli do
       end
 
       it "doesn't output anything but exitstatus when combined with parallel" do
-        run_exe 'spellr --quiet --parallel'
+        spellr '--quiet --parallel'
 
         expect(stderr).to be_empty
         expect(exitstatus).to eq 1
@@ -555,33 +584,33 @@ RSpec.describe 'command line', type: :cli do
 
     describe '--wordlist' do
       it 'returns the list of unmatched words' do
-        run_exe 'spellr --wordlist'
+        spellr '--wordlist'
 
         expect(stderr).to be_empty
         expect(exitstatus).to eq 1
-        expect(stdout).to eq <<~WORDS.chomp
+        expect(stdout).to have_output <<~WORDS
           amet
           dolar
         WORDS
       end
 
       it 'can be combined with --parallel' do
-        run_exe 'spellr --wordlist --parallel'
+        spellr '--wordlist --parallel'
 
         expect(stderr).to be_empty
         expect(exitstatus).to eq 1
-        expect(stdout).to eq <<~WORDS.chomp
+        expect(stdout).to have_output <<~WORDS
           amet
           dolar
         WORDS
       end
 
       it 'can be combined with --no-parallel' do
-        run_exe 'spellr --wordlist --no-parallel'
+        spellr '--wordlist --no-parallel'
 
         expect(stderr).to be_empty
         expect(exitstatus).to eq 1
-        expect(stdout).to eq <<~WORDS.chomp
+        expect(stdout).to have_output <<~WORDS
           amet
           dolar
         WORDS
@@ -591,7 +620,7 @@ RSpec.describe 'command line', type: :cli do
         stub_fs_file '.spellr.yml', <<~YML
           word_minimum_length: 6
         YML
-        run_exe "spellr --wordlist --config=#{Dir.pwd}/.spellr.yml"
+        spellr "--wordlist --config=#{Spellr.pwd}/.spellr.yml"
 
         expect(stderr).to be_empty
         expect(stdout).to be_empty
@@ -599,17 +628,18 @@ RSpec.describe 'command line', type: :cli do
       end
 
       it 'returns an error for invalid files' do
-        FileUtils.mkdir 'invalid_dir'
+        invalid_dir = Spellr.pwd.join('invalid_dir')
+        FileUtils.mkdir_p invalid_dir
 
-        FileUtils.cp("#{__dir__}/support/invalid_file", './invalid_dir')
-        run_exe 'spellr --wordlist'
+        FileUtils.cp("#{__dir__}/support/invalid_file", invalid_dir)
+        spellr '--wordlist'
 
-        expect(stderr).to eq <<~WORDS.chomp
+        expect(stderr).to have_output <<~WORDS
           Skipped unreadable file: #{aqua 'invalid_dir/invalid_file'}
         WORDS
 
         expect(exitstatus).to eq 1
-        expect(stdout).to eq <<~WORDS.chomp
+        expect(stdout).to have_output <<~WORDS
           amet
           dolar
         WORDS
@@ -618,11 +648,11 @@ RSpec.describe 'command line', type: :cli do
 
     describe 'spellr' do
       it 'returns the list of unmatched words and their locations' do
-        run_exe 'spellr'
+        spellr
 
         expect(stderr).to be_empty
         expect(exitstatus).to eq 1
-        expect(stdout).to eq <<~WORDS.chomp
+        expect(stdout).to have_output <<~WORDS
           #{aqua 'check.txt:1:12'} lorem ipsum #{red 'dolar'}
           #{aqua 'check.txt:3:2'} #{red 'dolar'} amet
           #{aqua 'check.txt:3:8'} dolar #{red 'amet'}
@@ -633,11 +663,11 @@ RSpec.describe 'command line', type: :cli do
       end
 
       it 'can be run with --no-parallel' do
-        run_exe 'spellr --no-parallel'
+        spellr '--no-parallel'
 
         expect(stderr).to be_empty
         expect(exitstatus).to eq 1
-        expect(stdout).to eq <<~WORDS.chomp
+        expect(stdout).to have_output <<~WORDS
           #{aqua 'check.txt:1:12'} lorem ipsum #{red 'dolar'}
           #{aqua 'check.txt:3:2'} #{red 'dolar'} amet
           #{aqua 'check.txt:3:8'} dolar #{red 'amet'}
@@ -655,24 +685,29 @@ RSpec.describe 'command line', type: :cli do
 
     describe '--interactive' do
       it 'returns the first unmatched term and a prompt' do
-        run_exe 'spellr -i' do |stdout, _|
-          expect(stdout).to print <<~STDOUT.chomp
+        spellr '-i' do
+          expect(stdout).to have_output <<~STDOUT.chomp
             #{aqua 'check.txt:1:12'} lorem ipsum #{red 'dolar'}
             #{prompt}
           STDOUT
+
+          expect(exitstatus).to eq nil
+          expect(stderr).to be_empty
         end
       end
 
       it 'returns the interactive command help' do
-        run_exe 'spellr -i' do |stdout, stdin|
-          expect(stdout).to print <<~STDOUT.chomp
+        spellr '-i' do
+          expect(stdout).to have_output <<~STDOUT.chomp
             #{aqua 'check.txt:1:12'} lorem ipsum #{red 'dolar'}
             #{prompt}
           STDOUT
+          expect(exitstatus).to eq nil
+          expect(stderr).to be_empty
 
           stdin.print 'h'
 
-          expect(stdout).to print <<~STDOUT
+          expect(stdout).to have_output <<~STDOUT.chomp
 
             #{aqua 'check.txt:1:12'} lorem ipsum #{red 'dolar'}
 
@@ -689,7 +724,7 @@ RSpec.describe 'command line', type: :cli do
 
           stdin.print 's'
 
-          expect(stdout).to print <<~STDOUT
+          expect(stdout).to have_output <<~STDOUT.chomp
 
             #{aqua 'check.txt:1:12'} lorem ipsum #{red 'dolar'}
 
@@ -706,30 +741,34 @@ RSpec.describe 'command line', type: :cli do
             #{aqua 'check.txt:3:2'} #{red 'dolar'} amet
             #{prompt}
           STDOUT
+
+          expect(stderr).to be_empty
+          expect(exitstatus).to eq nil
         end
       end
 
       it 'exits when ctrl C' do
-        run_exe 'spellr -i' do |stdout, stdin, pid|
-          expect(stdout).to print <<~STDOUT.chomp
+        spellr '-i' do
+          expect(stdout).to have_output <<~STDOUT.chomp
             #{aqua 'check.txt:1:12'} lorem ipsum #{red 'dolar'}
             #{prompt}
           STDOUT
 
           stdin.print "\u0003" # ctrl c
 
-          expect(stdout).to print <<~STDOUT.chomp
+          expect(stdout).to have_output <<~STDOUT
             #{aqua 'check.txt:1:12'} lorem ipsum #{red 'dolar'}
             #{prompt '^C'}
           STDOUT
 
-          expect(pid).to have_exitstatus(1)
+          expect(exitstatus).to eq 1
+          expect(stderr).to be_empty
         end
       end
 
       it 'ignores up' do
-        run_exe 'spellr -i' do |stdout, stdin|
-          expect(stdout).to print <<~STDOUT.chomp
+        spellr '-i' do
+          expect(stdout).to have_output <<~STDOUT.chomp
             #{aqua 'check.txt:1:12'} lorem ipsum #{red 'dolar'}
             #{prompt}
           STDOUT
@@ -738,23 +777,26 @@ RSpec.describe 'command line', type: :cli do
 
           sleep 0.1
 
-          expect(stdout).to print <<~STDOUT.chomp
+          expect(stdout).to have_output <<~STDOUT.chomp
             #{aqua 'check.txt:1:12'} lorem ipsum #{red 'dolar'}
             #{prompt}
           STDOUT
+
+          expect(exitstatus).to eq nil
+          expect(stderr).to be_empty
         end
       end
 
       it 'returns the next unmatched term and a prompt after skipping' do
-        run_exe 'spellr -i' do |stdout, stdin|
-          expect(stdout).to print <<~STDOUT.chomp
+        spellr '-i' do
+          expect(stdout).to have_output <<~STDOUT.chomp
             #{aqua 'check.txt:1:12'} lorem ipsum #{red 'dolar'}
             #{prompt}
           STDOUT
 
           stdin.print 's'
 
-          expect(stdout).to print <<~STDOUT.chomp
+          expect(stdout).to have_output <<~STDOUT.chomp
             #{aqua 'check.txt:1:12'} lorem ipsum #{red 'dolar'}
             #{prompt 's'}
             Skipped #{red 'dolar'}
@@ -764,7 +806,7 @@ RSpec.describe 'command line', type: :cli do
 
           stdin.print 's'
 
-          expect(stdout).to print <<~STDOUT.chomp
+          expect(stdout).to have_output <<~STDOUT.chomp
             #{aqua 'check.txt:1:12'} lorem ipsum #{red 'dolar'}
             #{prompt 's'}
             Skipped #{red 'dolar'}
@@ -777,7 +819,7 @@ RSpec.describe 'command line', type: :cli do
 
           stdin.print 's'
 
-          expect(stdout).to print <<~STDOUT.chomp
+          expect(stdout).to have_output <<~STDOUT
             #{aqua 'check.txt:1:12'} lorem ipsum #{red 'dolar'}
             #{prompt 's'}
             Skipped #{red 'dolar'}
@@ -791,21 +833,23 @@ RSpec.describe 'command line', type: :cli do
             1 file checked
             3 errors found
             3 errors skipped
-
           STDOUT
+
+          expect(stderr).to be_empty
+          expect(exitstatus).to eq 1
         end
       end
 
       it 'returns the next unmatched term and a prompt after skipping with S' do
-        run_exe 'spellr -i' do |stdout, stdin|
-          expect(stdout).to print <<~STDOUT.chomp
+        spellr '-i' do
+          expect(stdout).to have_output <<~STDOUT.chomp
             #{aqua 'check.txt:1:12'} lorem ipsum #{red 'dolar'}
             #{prompt}
           STDOUT
 
           stdin.print 'S'
 
-          expect(stdout).to print <<~STDOUT.chomp
+          expect(stdout).to have_output <<~STDOUT.chomp
             #{aqua 'check.txt:1:12'} lorem ipsum #{red 'dolar'}
             #{prompt 'S'}
             Skipped #{red 'dolar'}
@@ -816,7 +860,7 @@ RSpec.describe 'command line', type: :cli do
 
           stdin.print 'S'
 
-          expect(stdout).to print <<~STDOUT.chomp
+          expect(stdout).to have_output <<~STDOUT
             #{aqua 'check.txt:1:12'} lorem ipsum #{red 'dolar'}
             #{prompt 'S'}
             Skipped #{red 'dolar'}
@@ -829,19 +873,22 @@ RSpec.describe 'command line', type: :cli do
             3 errors found
             3 errors skipped
           STDOUT
+
+          expect(stderr).to be_empty
+          expect(exitstatus).to eq 1
         end
       end
 
       it 'can bail early when trying to add with a' do
-        run_exe 'spellr -i' do |stdout, stdin, pid|
-          expect(stdout).to print <<~STDOUT
+        spellr '-i' do
+          expect(stdout).to have_output <<~STDOUT.chomp
             #{aqua 'check.txt:1:12'} lorem ipsum #{red 'dolar'}
             #{prompt}
           STDOUT
 
           stdin.print 'a'
 
-          expect(stdout).to print <<~STDOUT.chomp
+          expect(stdout).to have_output <<~STDOUT.chomp
             #{aqua 'check.txt:1:12'} lorem ipsum #{red 'dolar'}
             #{prompt 'a'}
 
@@ -852,7 +899,7 @@ RSpec.describe 'command line', type: :cli do
 
           stdin.print "\u0003" # ctrl c
 
-          expect(stdout).to print <<~STDOUT.chomp
+          expect(stdout).to have_output <<~STDOUT.chomp
 
 
 
@@ -865,7 +912,7 @@ RSpec.describe 'command line', type: :cli do
 
           stdin.print "\u0003" # ctrl c
 
-          expect(stdout).to print <<~STDOUT.chomp
+          expect(stdout).to have_output <<~STDOUT
 
 
 
@@ -876,20 +923,21 @@ RSpec.describe 'command line', type: :cli do
             #{prompt '^C'}
           STDOUT
 
-          expect(pid).to have_exitstatus(1)
+          expect(stderr).to be_empty
+          expect(exitstatus).to eq 1
         end
       end
 
       it "asks me again when i chose a language that doesn't exist when adding with a" do
-        run_exe 'spellr -i' do |stdout, stdin|
-          expect(stdout).to print <<~STDOUT.chomp
+        spellr '-i' do
+          expect(stdout).to have_output <<~STDOUT.chomp
             #{aqua 'check.txt:1:12'} lorem ipsum #{red 'dolar'}
             #{prompt}
           STDOUT
 
           stdin.print 'a'
 
-          expect(stdout).to print <<~STDOUT
+          expect(stdout).to have_output <<~STDOUT.chomp
             #{aqua 'check.txt:1:12'} lorem ipsum #{red 'dolar'}
             #{prompt 'a'}
 
@@ -902,7 +950,7 @@ RSpec.describe 'command line', type: :cli do
 
           sleep 0.1 # make sure nothing has changed
 
-          expect(stdout).to print <<~STDOUT
+          expect(stdout).to have_output <<~STDOUT.chomp
             #{aqua 'check.txt:1:12'} lorem ipsum #{red 'dolar'}
             #{prompt 'a'}
 
@@ -910,19 +958,22 @@ RSpec.describe 'command line', type: :cli do
               [^#{bold 'C'}] to go back
               Add #{red 'dolar'} to which wordlist? [ ]
           STDOUT
+
+          expect(stderr).to be_empty
+          expect(exitstatus).to eq nil
         end
       end
 
       it 'returns the next unmatched term and a prompt after adding with a' do
-        run_exe 'spellr -i' do |stdout, stdin|
-          expect(stdout).to print <<~STDOUT.chomp
+        spellr '-i' do
+          expect(stdout).to have_output <<~STDOUT.chomp
             #{aqua 'check.txt:1:12'} lorem ipsum #{red 'dolar'}
             #{prompt}
           STDOUT
 
           stdin.print 'a'
 
-          expect(stdout).to print <<~STDOUT
+          expect(stdout).to have_output <<~STDOUT.chomp
             #{aqua 'check.txt:1:12'} lorem ipsum #{red 'dolar'}
             #{prompt 'a'}
 
@@ -933,7 +984,7 @@ RSpec.describe 'command line', type: :cli do
 
           stdin.print 'e'
 
-          expect(stdout).to print <<~STDOUT.chomp
+          expect(stdout).to have_output <<~STDOUT.chomp
             #{aqua 'check.txt:1:12'} lorem ipsum #{red 'dolar'}
             #{prompt 'a'}
 
@@ -954,7 +1005,7 @@ RSpec.describe 'command line', type: :cli do
 
           stdin.print 'a'
 
-          expect(stdout).to print <<~STDOUT
+          expect(stdout).to have_output <<~STDOUT.chomp
             #{aqua 'check.txt:1:12'} lorem ipsum #{red 'dolar'}
             #{prompt 'a'}
 
@@ -973,7 +1024,7 @@ RSpec.describe 'command line', type: :cli do
 
           stdin.print 'e'
 
-          expect(stdout).to print <<~STDOUT
+          expect(stdout).to have_output <<~STDOUT
             #{aqua 'check.txt:1:12'} lorem ipsum #{red 'dolar'}
             #{prompt 'a'}
 
@@ -1002,6 +1053,9 @@ RSpec.describe 'command line', type: :cli do
             ipsum
             lorem
           FILE
+
+          expect(stderr).to be_empty
+          expect(exitstatus).to eq 0
         end
       end
 
@@ -1010,15 +1064,16 @@ RSpec.describe 'command line', type: :cli do
           languages:
             lorem: {}
         YML
-        run_exe "spellr -i --config=#{Dir.pwd}/.spellr.yml" do |stdout, stdin|
-          expect(stdout).to print <<~STDOUT.chomp
+
+        spellr "-i --config=#{Spellr.pwd}/.spellr.yml" do
+          expect(stdout).to have_output <<~STDOUT.chomp
             #{aqua 'check.txt:1:12'} lorem ipsum #{red 'dolar'}
             #{prompt}
           STDOUT
 
           stdin.print 'a'
 
-          expect(stdout).to print <<~STDOUT.chomp
+          expect(stdout).to have_output <<~STDOUT.chomp
             #{aqua 'check.txt:1:12'} lorem ipsum #{red 'dolar'}
             #{prompt 'a'}
 
@@ -1030,7 +1085,7 @@ RSpec.describe 'command line', type: :cli do
 
           stdin.print 'l'
 
-          expect(stdout).to print <<~STDOUT.chomp
+          expect(stdout).to have_output <<~STDOUT.chomp
             #{aqua 'check.txt:1:12'} lorem ipsum #{red 'dolar'}
             #{prompt 'a'}
 
@@ -1047,15 +1102,15 @@ RSpec.describe 'command line', type: :cli do
       end
 
       it 'can bail early when trying to replace with R' do
-        run_exe 'spellr -i' do |stdout, stdin, pid|
-          expect(stdout).to print <<~STDOUT
+        spellr '-i' do
+          expect(stdout).to have_output <<~STDOUT.chomp
             #{aqua 'check.txt:1:12'} lorem ipsum #{red 'dolar'}
             #{prompt}
           STDOUT
 
           stdin.print 'R'
 
-          expect(stdout).to print <<~STDOUT.chomp
+          expect(stdout).to have_output <<~STDOUT.chomp
             #{aqua 'check.txt:1:12'} lorem ipsum #{red 'dolar'}
             #{prompt 'R'}
 
@@ -1065,7 +1120,7 @@ RSpec.describe 'command line', type: :cli do
 
           stdin.print "something\u0003" # ctrl c
 
-          expect(stdout).to print <<~STDOUT.chomp
+          expect(stdout).to have_output <<~STDOUT.chomp
 
 
 
@@ -1076,20 +1131,30 @@ RSpec.describe 'command line', type: :cli do
 
           stdin.print "\u0003" # ctrl c
 
-          expect(pid).to have_exitstatus(1)
+          expect(stdout).to have_output <<~STDOUT
+
+
+
+
+            #{aqua 'check.txt:1:12'} lorem ipsum #{red 'dolar'}
+            #{prompt '^C'}
+          STDOUT
+
+          expect(stderr).to be_empty
+          expect(exitstatus).to eq 1
         end
       end
 
       it 'returns the next unmatched term and a prompt after replacing with R' do
-        run_exe 'spellr -i' do |stdout, stdin|
-          expect(stdout).to print <<~STDOUT.chomp
+        spellr '-i' do
+          expect(stdout).to have_output <<~STDOUT.chomp
             #{aqua 'check.txt:1:12'} lorem ipsum #{red 'dolar'}
             #{prompt}
           STDOUT
 
           stdin.print 'R'
 
-          expect(stdout).to print <<~STDOUT.chomp
+          expect(stdout).to have_output <<~STDOUT.chomp
             #{aqua 'check.txt:1:12'} lorem ipsum #{red 'dolar'}
             #{prompt 'R'}
 
@@ -1099,7 +1164,7 @@ RSpec.describe 'command line', type: :cli do
 
           stdin.print "es\n"
 
-          expect(stdout).to print <<~STDOUT.chomp
+          expect(stdout).to have_output <<~STDOUT.chomp
             #{aqua 'check.txt:1:12'} lorem ipsum #{red 'dolar'}
             #{prompt 'R'}
 
@@ -1119,7 +1184,7 @@ RSpec.describe 'command line', type: :cli do
 
           stdin.print 'a'
 
-          expect(stdout).to print <<~STDOUT
+          expect(stdout).to have_output <<~STDOUT.chomp
             #{aqua 'check.txt:1:12'} lorem ipsum #{red 'dolar'}
             #{prompt 'R'}
 
@@ -1137,7 +1202,7 @@ RSpec.describe 'command line', type: :cli do
 
           stdin.print 'e'
 
-          expect(stdout).to print <<~STDOUT.chomp
+          expect(stdout).to have_output <<~STDOUT.chomp
             #{aqua 'check.txt:1:12'} lorem ipsum #{red 'dolar'}
             #{prompt 'R'}
 
@@ -1172,7 +1237,7 @@ RSpec.describe 'command line', type: :cli do
 
           stdin.print 's'
 
-          expect(stdout).to print <<~STDOUT
+          expect(stdout).to have_output <<~STDOUT
             #{aqua 'check.txt:1:12'} lorem ipsum #{red 'dolar'}
             #{prompt 'R'}
 
@@ -1199,19 +1264,22 @@ RSpec.describe 'command line', type: :cli do
             2 errors fixed
             1 word added
           STDOUT
+
+          expect(stderr).to be_empty
+          expect(exitstatus).to eq 1
         end
       end
 
       it 'can bail early when trying to replace with r' do
-        run_exe 'spellr -i' do |stdout, stdin, pid|
-          expect(stdout).to print <<~STDOUT
+        spellr '-i' do
+          expect(stdout).to have_output <<~STDOUT.chomp
             #{aqua 'check.txt:1:12'} lorem ipsum #{red 'dolar'}
             #{prompt}
           STDOUT
 
           stdin.print 'r'
 
-          expect(stdout).to print <<~STDOUT.chomp
+          expect(stdout).to have_output <<~STDOUT.chomp
             #{aqua 'check.txt:1:12'} lorem ipsum #{red 'dolar'}
             #{prompt 'r'}
 
@@ -1221,7 +1289,7 @@ RSpec.describe 'command line', type: :cli do
 
           stdin.print "\u0003" # ctrl c
 
-          expect(stdout).to print <<~STDOUT.chomp
+          expect(stdout).to have_output <<~STDOUT.chomp
 
 
 
@@ -1232,7 +1300,7 @@ RSpec.describe 'command line', type: :cli do
 
           stdin.print "\u0003" # ctrl c
 
-          expect(stdout).to print <<~STDOUT.chomp
+          expect(stdout).to have_output <<~STDOUT
 
 
 
@@ -1241,20 +1309,21 @@ RSpec.describe 'command line', type: :cli do
             #{prompt '^C'}
           STDOUT
 
-          expect(pid).to have_exitstatus(1)
+          expect(stderr).to be_empty
+          expect(exitstatus).to eq 1
         end
       end
 
       it 'disallows replacing with nothing when replacing with r' do
-        run_exe 'spellr -i' do |stdout, stdin|
-          expect(stdout).to print <<~STDOUT.chomp
+        spellr '-i' do
+          expect(stdout).to have_output <<~STDOUT.chomp
             #{aqua 'check.txt:1:12'} lorem ipsum #{red 'dolar'}
             #{prompt}
           STDOUT
 
           stdin.print 'r'
 
-          expect(stdout).to print <<~STDOUT.chomp
+          expect(stdout).to have_output <<~STDOUT.chomp
             #{aqua 'check.txt:1:12'} lorem ipsum #{red 'dolar'}
             #{prompt 'r'}
 
@@ -1264,7 +1333,7 @@ RSpec.describe 'command line', type: :cli do
 
           stdin.print "\b" * 17
 
-          expect(stdout).to print <<~STDOUT.chomp
+          expect(stdout).to have_output <<~STDOUT.chomp
             #{aqua 'check.txt:1:12'} lorem ipsum #{red 'dolar'}
             #{prompt 'r'}
 
@@ -1275,7 +1344,7 @@ RSpec.describe 'command line', type: :cli do
           stdin.puts ''
 
           # just put the prompt again
-          expect(stdout).to print <<~STDOUT.chomp
+          expect(stdout).to have_output <<~STDOUT.chomp
 
             #{aqua 'check.txt:1:12'} lorem ipsum #{red 'dolar'}
             #{prompt 'r'}
@@ -1283,19 +1352,22 @@ RSpec.describe 'command line', type: :cli do
               #{lighten '[^C] to go back'}
               Replace #{red 'dolar'} with: \e[32mdolar
           STDOUT
+
+          expect(stderr).to have_output ''
+          expect(exitstatus).to eq nil
         end
       end
 
       it 'disallows replacing with the same when replacing with r' do
-        run_exe 'spellr -i' do |stdout, stdin|
-          expect(stdout).to print <<~STDOUT.chomp
+        spellr '-i' do
+          expect(stdout).to have_output <<~STDOUT.chomp
             #{aqua 'check.txt:1:12'} lorem ipsum #{red 'dolar'}
             #{prompt}
           STDOUT
 
           stdin.print 'r'
 
-          expect(stdout).to print <<~STDOUT.chomp
+          expect(stdout).to have_output <<~STDOUT.chomp
             #{aqua 'check.txt:1:12'} lorem ipsum #{red 'dolar'}
             #{prompt 'r'}
 
@@ -1307,7 +1379,7 @@ RSpec.describe 'command line', type: :cli do
           sleep 0.1
 
           # just put the prompt again
-          expect(stdout).to print <<~STDOUT.chomp
+          expect(stdout).to have_output <<~STDOUT.chomp
 
             #{aqua 'check.txt:1:12'} lorem ipsum #{red 'dolar'}
             #{prompt 'r'}
@@ -1315,19 +1387,22 @@ RSpec.describe 'command line', type: :cli do
               #{lighten '[^C] to go back'}
               Replace #{red 'dolar'} with: \e[32mdolar
           STDOUT
+
+          expect(stderr).to be_empty
+          expect(exitstatus).to eq nil
         end
       end
 
       it 'returns the next unmatched term and a prompt after replacing with r' do
-        run_exe 'spellr -i' do |stdout, stdin|
-          expect(stdout).to print <<~STDOUT.chomp
+        spellr '-i' do
+          expect(stdout).to have_output <<~STDOUT.chomp
             #{aqua 'check.txt:1:12'} lorem ipsum #{red 'dolar'}
             #{prompt}
           STDOUT
 
           stdin.print 'r'
 
-          expect(stdout).to print <<~STDOUT.chomp
+          expect(stdout).to have_output <<~STDOUT.chomp
             #{aqua 'check.txt:1:12'} lorem ipsum #{red 'dolar'}
             #{prompt 'r'}
 
@@ -1337,7 +1412,7 @@ RSpec.describe 'command line', type: :cli do
 
           stdin.print "es\n"
 
-          expect(stdout).to print <<~STDOUT.chomp
+          expect(stdout).to have_output <<~STDOUT.chomp
             #{aqua 'check.txt:1:12'} lorem ipsum #{red 'dolar'}
             #{prompt 'r'}
 
@@ -1357,7 +1432,7 @@ RSpec.describe 'command line', type: :cli do
 
           stdin.print 'a'
 
-          expect(stdout).to print <<~STDOUT
+          expect(stdout).to have_output <<~STDOUT.chomp
             #{aqua 'check.txt:1:12'} lorem ipsum #{red 'dolar'}
             #{prompt 'r'}
 
@@ -1375,7 +1450,7 @@ RSpec.describe 'command line', type: :cli do
 
           stdin.print 'e'
 
-          expect(stdout).to print <<~STDOUT.chomp
+          expect(stdout).to have_output <<~STDOUT.chomp
             #{aqua 'check.txt:1:12'} lorem ipsum #{red 'dolar'}
             #{prompt 'r'}
 
@@ -1403,7 +1478,7 @@ RSpec.describe 'command line', type: :cli do
 
           stdin.print 's'
 
-          expect(stdout).to print <<~STDOUT.chomp
+          expect(stdout).to have_output <<~STDOUT.chomp
             #{aqua 'check.txt:1:12'} lorem ipsum #{red 'dolar'}
             #{prompt 'r'}
 
@@ -1428,7 +1503,7 @@ RSpec.describe 'command line', type: :cli do
 
           stdin.print 's'
 
-          expect(stdout).to print <<~STDOUT
+          expect(stdout).to have_output <<~STDOUT
             #{aqua 'check.txt:1:12'} lorem ipsum #{red 'dolar'}
             #{prompt 'r'}
 
@@ -1457,6 +1532,9 @@ RSpec.describe 'command line', type: :cli do
             1 error fixed
             1 word added
           STDOUT
+
+          expect(stderr).to be_empty
+          expect(exitstatus).to eq 1
         end
       end
     end

--- a/spec/file_list_spec.rb
+++ b/spec/file_list_spec.rb
@@ -5,7 +5,7 @@ require_relative '../lib/spellr/file_list'
 
 RSpec::Matchers.define :match_relative_paths do |*expected|
   match do |actual|
-    @actual = actual.map { |a| Pathname.new(a.to_s).relative_path_from(Pathname.pwd).to_s }
+    @actual = actual.map { |a| Pathname.new(a.to_s).relative_path_from(Spellr.pwd).to_s }
     expect(@actual).to match_array(expected)
   end
 
@@ -13,11 +13,9 @@ RSpec::Matchers.define :match_relative_paths do |*expected|
 end
 
 RSpec.describe Spellr::FileList do
-  around do |example|
-    with_temp_dir(example)
-  end
-
   before do
+    with_temp_dir
+
     stub_fs_file_list %w{
       foo.rb
       foo/bar.txt
@@ -98,7 +96,7 @@ RSpec.describe Spellr::FileList do
   end
 
   it 'can respect absolute paths' do
-    expect(described_class.new(Pathname.pwd.join('foo.rb').to_s).to_a).to match_relative_paths(
+    expect(described_class.new(Spellr.pwd.join('foo.rb').to_s).to_a).to match_relative_paths(
       'foo.rb'
     )
   end

--- a/spec/file_spec.rb
+++ b/spec/file_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe Spellr::File do
   describe '#hashbang' do
     subject { described_class.new(path) }
 
-    around { |example| with_temp_dir(example) }
+    before { with_temp_dir }
 
     context 'when it has an extension' do
       let(:path) { stub_fs_file('whatever.rb', <<~FILE) }

--- a/spec/support/eventually.rb
+++ b/spec/support/eventually.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+module Eventually
+  class << self
+    def equal?(value, seconds)
+      loop_within(seconds) do
+        output = yield
+        return true if output == value
+      end
+      false
+    end
+
+    private
+
+    def loop_within(seconds)
+      # timeout is just because it gets stuck sometimes
+      Timeout.timeout(seconds + 1) do
+        start_time = monotonic_time
+        yield until start_time + seconds < monotonic_time
+      end
+    end
+
+    def monotonic_time
+      Process.clock_gettime(Process::CLOCK_MONOTONIC)
+    end
+  end
+end

--- a/spec/support/io_string_methods.rb
+++ b/spec/support/io_string_methods.rb
@@ -1,0 +1,88 @@
+# frozen_string_literal: true
+
+require 'tty_string'
+require_relative 'eventually'
+
+class ExitStatus
+  def initialize(pid)
+    @pid = pid
+  end
+
+  def ==(other)
+    Eventually.equal?(other, 3) { status }
+  end
+
+  def status
+    @status ||= PTY.check(@pid)&.exitstatus
+  end
+
+  def inspect
+    status.inspect
+  end
+end
+
+# just so i get a nice diff.
+RSpec::Matchers.define :have_output do |expected|
+  match do |actual|
+    actual == expected # rubocop:disable Lint/Void i'm doing naughty things.
+
+    @actual = actual.to_s
+    expect(@actual).to eq(expected)
+  end
+
+  diffable
+end
+
+module StringIOStringMethods
+  def ==(other)
+    to_s == other
+  end
+
+  def to_s
+    TTYString.new(string, clear_style: false).to_s
+  end
+
+  def to_str
+    to_s
+  end
+
+  def inspect
+    string.inspect
+  end
+
+  def empty?
+    string.empty?
+  end
+
+  def each_line(&block)
+    to_s.each_line(&block)
+  end
+
+  def readlines
+    string.each_line.to_a
+  end
+end
+
+module IOStringMethods
+  def string # rubocop:disable Metrics/MethodLength
+    @string ||= ''
+    @string += read_nonblock(4096)
+  rescue IO::WaitReadable
+    (readable? && retry) || @string
+  rescue Errno::EIO, IOError
+    @string
+  end
+
+  def ==(other)
+    Eventually.equal?(other, 2) { to_s }
+  end
+
+  def readable?
+    IO.select([self], nil, nil, 0)
+  end
+
+  def empty?
+    sleep 0.1
+    string.empty?
+  end
+end

--- a/spec/support/pre_pty.rb
+++ b/spec/support/pre_pty.rb
@@ -1,6 +1,21 @@
 # frozen_string_literal: true
 
-require 'simplecov'
+require_relative '../../lib/spellr/pwd'
 
-SimpleCov.command_name "CLI #{Process.pid} #{ENV['SPELLR_TEST_DESCRIPTION']} #{rand}"
-SimpleCov.start
+module Spellr
+  module_function
+
+  def pwd
+    Pathname.new(ENV['SPELLR_TEST_PWD'])
+  end
+
+  def pwd_s
+    ENV['SPELLR_TEST_PWD']
+  end
+end
+
+if ENV['SPELLR_SIMPLECOV']
+  require 'simplecov'
+  SimpleCov.command_name "CLI #{Process.pid}"
+  SimpleCov.start
+end

--- a/spec/token_spec.rb
+++ b/spec/token_spec.rb
@@ -6,11 +6,11 @@ require_relative '../lib/spellr/tokenizer'
 require_relative '../lib/spellr/file'
 
 RSpec.describe Spellr::Token do
-  around { |example| with_temp_dir(example) }
+  before { with_temp_dir }
 
   let(:file) do
     stub_fs_file 'foo', "first line\n  second line\n🤷🏼‍♀️ 🇳🇿 char vs byte\ncafé"
-    Spellr::File.new(Pathname.pwd.join('foo'))
+    Spellr::File.new(Spellr.pwd.join('foo'))
   end
 
   let(:tokens) do

--- a/spec/wordlist_spec.rb
+++ b/spec/wordlist_spec.rb
@@ -3,9 +3,9 @@
 require_relative '../lib/spellr/wordlist'
 
 RSpec.describe Spellr::Wordlist do
-  subject { described_class.new(Pathname.pwd.join('wordlist').to_s) }
+  subject { described_class.new(Spellr.pwd.join('wordlist').to_s) }
 
-  around { |e| with_temp_dir(e) }
+  before { with_temp_dir }
 
   context 'when missing' do
     describe '#include?' do

--- a/spellr.gemspec
+++ b/spellr.gemspec
@@ -28,7 +28,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   spec.add_development_dependency 'bundler', '~> 2.0'
-  spec.add_development_dependency 'leftovers', '>= 0.2.0'
+  spec.add_development_dependency 'leftovers', '>= 0.2.2'
   spec.add_development_dependency 'mime-types', '~> 3.3.1'
   spec.add_development_dependency 'nokogiri'
   spec.add_development_dependency 'pry'
@@ -41,6 +41,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'tty_string', '>= 0.2.1'
   spec.add_development_dependency 'webmock', '~> 3.8'
 
-  spec.add_dependency 'fast_ignore', '>= 0.6.0'
+  spec.add_dependency 'fast_ignore', '>= 0.10.0'
   spec.add_dependency 'parallel', '~> 1.0'
 end


### PR DESCRIPTION
- Spellr now only pays attention to Spellr.pwd. Dir.pwd can be whatever
- All output goes through Spellr.config.output Now we can override it.
- tests are twice as fast. Fewer warnings
- spec/support is a goddam mess, but i'll get to that.