### PR TITLE
Require stringio in tokenizer

### DIFF
--- a/lib/spellr/tokenizer.rb
+++ b/lib/spellr/tokenizer.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require 'stringio'
 require_relative 'token'
 require_relative 'column_location'
 require_relative 'line_location'


### PR DESCRIPTION
Upgrading to 6.4.4 of factory_bot_rails breaks spellr https://github.com/thoughtbot/factory_bot_rails/compare/v6.4.3...v6.4.4.

We get the below error 

```
bundler: failed to load command: spellr (/Users/alexdeng/.rbenv/versions/3.3.1/bin/spellr)
/Users/alexdeng/.rbenv/versions/3.3.1/lib/ruby/gems/3.3.0/gems/spellr-0.11.0/lib/spellr/tokenizer.rb:15:in `initialize': uninitialized constant Spellr::Tokenizer::StringIO (NameError)
```

Adding the explicit require of stringio sorts this.
